### PR TITLE
Recovering vim's 'f' find.

### DIFF
--- a/plugin/python_ifold.a.vim
+++ b/plugin/python_ifold.a.vim
@@ -16,7 +16,7 @@ if !exists("g:ifold_mode")
     let g:ifold_mode = 0
 endif
 
-map <buffer> f :call ToggleFold()<CR> 
+map <buffer> <Leader>f :call ToggleFold()<CR>
 
 let w:nestinglevel = 0
 let w:signature = 0

--- a/plugin/python_ifold.b.vim
+++ b/plugin/python_ifold.b.vim
@@ -16,7 +16,7 @@ if !exists("g:ifold_mode")
     let g:ifold_mode = 1
 endif
 
-map <buffer> f :call ToggleFold()<CR> 
+map <buffer> <Leader>f :call ToggleFold()<CR>
 
 let w:nestinglevel = 0
 let w:signature = 0

--- a/plugin/python_ifold.c.vim
+++ b/plugin/python_ifold.c.vim
@@ -16,7 +16,7 @@ if !exists("g:ifold_mode")
     let g:ifold_mode = 1
 endif
 
-map <buffer> f :call ToggleFold()<CR> 
+map <buffer> <Leader>f :call ToggleFold()<CR>
 
 set tabstop=4
 set softtabstop=4


### PR DESCRIPTION
Now the script maps <Leader>f to change the fold method, allowing normal
use of the 'find' vim command.
